### PR TITLE
manual.md: avoid external calls in Procmail recipe; bounce on error

### DIFF
--- a/content/docs/Installation/manual.md
+++ b/content/docs/Installation/manual.md
@@ -87,14 +87,11 @@ TRAP=/etc/webmin/virtual-server/procmail-logger.pl
 VIRTUALMIN=|/etc/webmin/virtual-server/lookup-domain.pl $LOGNAME
 EXITCODE=$?
 :0
-* ?/bin/test "$EXITCODE" = "73"
-/dev/null
-EXITCODE=0
-:0
-* ?/bin/test "$VIRTUALMIN" != ""
-{
-INCLUDERC=/etc/webmin/virtual-server/procmail/$VIRTUALMIN
-}
+* ! EXITCODE   ?? ^0$
+* ! VIRTUALMIN ?? ^$
+{ EXITCODE=73 HOST= }
+:0E
+{ INCLUDERC=/etc/webmin/virtual-server/procmail/$VIRTUALMIN }
 ORGMAIL=$HOME/Maildir/
 DEFAULT=$HOME/Maildir/
 DROPPRIVS=yes


### PR DESCRIPTION
This was brought to my attention via a question on Server Fault: https://serverfault.com/questions/1163955/how-do-i-solve-procmail-not-writing-to-home-maildir/1163956

This proposed change introduces the following changes:

* If `lookup-domain.pl` fails, we generate a bounce message, instead of silently discarding email to `/dev/null` and pretending everything is fine.
* This avoids the unnecessary external calls to test to perform string comparisons, which Procmail out of the box does very well by itself.

This only changes the manual installation instructions. I went looking for a file which would contain something similar for non-manual installations, but could not find it. Arguably if there is such a thing, it should be kept in sync.