### PR TITLE
Sury/PHP key is placed in deprecated location for Debian

### DIFF
--- a/content/docs/Server Components/configuring-multiple-php-versions.md
+++ b/content/docs/Server Components/configuring-multiple-php-versions.md
@@ -26,7 +26,7 @@ Virtualmin allows the selection of different PHP versions and execution modes fo
 
 1. **Enable Sury/PHP repository**
    ```text
-   apt-get -y install apt-transport-https lsb-release ca-certificates curl && curl -sSL -o /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg && sh -c 'echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/sury-debian-php-$(lsb_release -sc).list' && apt-get update
+   apt-get -y install apt-transport-https lsb-release ca-certificates curl && curl -sSL -o /usr/share/keyrings/debsuryorg-archive-keyring.gpg https://packages.sury.org/php/apt.gpg && sh -c 'echo "deb [signed-by=/usr/share/keyrings/debsuryorg-archive-keyring.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/sury-debian-php-$(lsb_release -sc).list' && apt-get update
    ```
 2. **Install PHP packages**
    ```text


### PR DESCRIPTION
Sury/PHP key should be in `/usr/share/keyrings/` instead of deprecated `/etc/apt/trusted.gpg.d/` 

The current key will be removed automatically when doing an apt upgrade

Added `signed-by` to sury apt source list to make it point to the correct key